### PR TITLE
fix(service): home directory for PIDFile

### DIFF
--- a/templates/sonar.service.erb
+++ b/templates/sonar.service.erb
@@ -7,7 +7,7 @@ Wants=network-online.target
 ExecStart=<%= @installroot -%>/sonar/bin/<%= @arch.to_s -%>/sonar.sh start
 ExecStop=<%= @installroot -%>/sonar/bin/<%= @arch.to_s -%>/sonar.sh stop
 ExecReload=<%= @installroot -%>/sonar/bin/<%= @arch.to_s -%>/sonar.sh restart
-PIDFile=<%= @home -%>/sonar.pid
+PIDFile=<%= @real_home -%>/sonar.pid
 Type=forking
 User=<%= @user %>
 Group=<%= @user %>


### PR DESCRIPTION
Hi,
Thank you for your work but I detected a problem with the service.

In the case of `home` variable is unset 
https://github.com/juan-leon/puppet-sonarqube/blob/d6205d8586539459cb49ff04ad9be13d84541cba/manifests/init.pp#L21
The value of `PIDFILE` in the service is '/sonar.pid' 
https://github.com/juan-leon/puppet-sonarqube/blob/d6205d8586539459cb49ff04ad9be13d84541cba/templates/sonar.service.erb#L10

My fix use the  `real_home` variable which manage the unset of home.

https://github.com/juan-leon/puppet-sonarqube/blob/d6205d8586539459cb49ff04ad9be13d84541cba/manifests/init.pp#L69-L73


Best regards.